### PR TITLE
Invalid 'Expires' makes response stale

### DIFF
--- a/methanol/src/main/java/com/github/mizosoft/methanol/CacheControl.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/CacheControl.java
@@ -27,7 +27,7 @@ import static com.github.mizosoft.methanol.internal.Utils.requireNonNegativeDura
 import static com.github.mizosoft.methanol.internal.Utils.requireValidHeaderValue;
 import static com.github.mizosoft.methanol.internal.Utils.requireValidToken;
 import static com.github.mizosoft.methanol.internal.Validate.requireArgument;
-import static com.github.mizosoft.methanol.internal.cache.HttpDates.toDeltaSeconds;
+import static com.github.mizosoft.methanol.internal.cache.HttpDates.parseDeltaSeconds;
 import static java.lang.String.format;
 
 import com.github.mizosoft.methanol.internal.text.HeaderValueTokenizer;
@@ -561,26 +561,26 @@ public final class CacheControl {
 
       switch (normalizedDirective) {
         case "max-age":
-          maxAge = toDeltaSeconds(argument);
+          maxAge = parseDeltaSeconds(argument);
           break;
         case "min-fresh":
-          minFresh = toDeltaSeconds(argument);
+          minFresh = parseDeltaSeconds(argument);
           break;
         case "s-maxage":
-          sMaxAge = toDeltaSeconds(argument);
+          sMaxAge = parseDeltaSeconds(argument);
           break;
         case "max-stale":
           if (argument.isEmpty()) {
             anyMaxStale = true;
           } else {
-            maxStale = toDeltaSeconds(argument);
+            maxStale = parseDeltaSeconds(argument);
           }
           break;
         case "stale-while-revalidate":
-          staleWhileRevalidate = toDeltaSeconds(argument);
+          staleWhileRevalidate = parseDeltaSeconds(argument);
           break;
         case "stale-if-error":
-          staleIfError = toDeltaSeconds(argument);
+          staleIfError = parseDeltaSeconds(argument);
           break;
         case "no-cache":
           noCache = true;

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheInterceptor.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheInterceptor.java
@@ -408,7 +408,7 @@ public final class CacheInterceptor implements Interceptor {
     return request
         .headers()
         .firstValue("If-Modified-Since")
-        .map(HttpDates::toHttpDate)
+        .flatMap(HttpDates::tryParseHttpDate)
         .map(value -> isModifiedSince(cacheResponse, value));
   }
 
@@ -480,7 +480,7 @@ public final class CacheInterceptor implements Interceptor {
         .headers()
         .firstValue("Last-Modified")
         .or(() -> cacheResponse.headers().firstValue("Date"))
-        .map(HttpDates::toHttpDate)
+        .flatMap(HttpDates::tryParseHttpDate)
         .orElseGet(() -> HttpDates.toUtcDateTime(cacheResponse.timeResponseReceived()))
         .isAfter(dateTime);
   }

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheResponse.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheResponse.java
@@ -56,7 +56,7 @@ public final class CacheResponse extends PublisherResponse implements Closeable 
         response,
         new CacheReadingPublisher(viewer, executor, readListener),
         viewer,
-        CacheStrategy.newBuilder(request, response).build(now));
+        CacheStrategy.create(request, response, now));
   }
 
   private CacheResponse(

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheStrategy.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/cache/CacheStrategy.java
@@ -24,6 +24,7 @@ package com.github.mizosoft.methanol.internal.cache;
 
 import static com.github.mizosoft.methanol.internal.cache.HttpDates.formatHttpDate;
 import static com.github.mizosoft.methanol.internal.cache.HttpDates.toUtcDateTime;
+import static com.github.mizosoft.methanol.internal.cache.HttpDates.tryParseHttpDate;
 
 import com.github.mizosoft.methanol.CacheControl;
 import com.github.mizosoft.methanol.MutableRequest;
@@ -48,22 +49,29 @@ class CacheStrategy {
 
   private final CacheControl requestCacheControl;
   private final CacheControl responseCacheControl;
+
+  /** The age of the cached response. */
   private final Duration age;
+
+  /** How much time the response stays fresh from when this strategy has been computed. */
   private final Duration freshness;
+
+  /** How much time the response has been stale since this strategy had been computed. */
   private final Duration staleness;
+
   private final Optional<LocalDateTime> lastModified;
   private final Optional<String> etag;
   private final boolean usesHeuristicFreshness;
 
-  CacheStrategy(Builder builder, Instant now) {
-    requestCacheControl = builder.requestCacheControl;
-    responseCacheControl = builder.responseCacheControl;
-    age = builder.computeAge(now);
-    freshness = builder.computeFreshnessLifetime().minus(age);
+  CacheStrategy(Factory factory, Instant now) {
+    requestCacheControl = factory.requestCacheControl;
+    responseCacheControl = factory.responseCacheControl;
+    age = factory.computeAge(now);
+    freshness = factory.computeFreshnessLifetime().minus(age);
     staleness = freshness.negated();
-    usesHeuristicFreshness = builder.usesHeuristicFreshness();
-    lastModified = builder.lastModified;
-    etag = builder.cacheResponseHeaders.firstValue("ETag");
+    usesHeuristicFreshness = factory.usesHeuristicFreshness();
+    lastModified = factory.lastModified;
+    etag = factory.cacheResponseHeaders.firstValue("ETag");
   }
 
   boolean canServeCacheResponse(StalenessRule stalenessRule) {
@@ -110,11 +118,11 @@ class CacheStrategy {
     return conditionalizedRequest.toImmutableRequest();
   }
 
-  static Builder newBuilder(HttpRequest request, TrackedResponse<?> cacheResponse) {
-    return new Builder(request, cacheResponse);
+  static CacheStrategy create(HttpRequest request, TrackedResponse<?> cacheResponse, Instant now) {
+    return new Factory(request, cacheResponse).create(now);
   }
 
-  static final class Builder {
+  static final class Factory {
     final Instant timeRequestSent;
     final Instant timeResponseReceived;
     final HttpHeaders cacheResponseHeaders;
@@ -125,14 +133,13 @@ class CacheStrategy {
     final Optional<LocalDateTime> expires;
     final Optional<LocalDateTime> lastModified;
 
-    Builder(HttpRequest request, TrackedResponse<?> cacheResponse) {
+    Factory(HttpRequest request, TrackedResponse<?> cacheResponse) {
       timeRequestSent = cacheResponse.timeRequestSent();
       timeResponseReceived = cacheResponse.timeResponseReceived();
       cacheResponseHeaders = cacheResponse.headers();
       requestCacheControl = CacheControl.parse(request.headers());
       responseCacheControl = CacheControl.parse(cacheResponse.headers());
       maxAge = requestCacheControl.maxAge().or(responseCacheControl::maxAge);
-      expires = cacheResponse.headers().firstValue("Expires").flatMap(HttpDates::tryParseHttpDate);
       lastModified =
           cacheResponse.headers().firstValue("Last-Modified").flatMap(HttpDates::tryParseHttpDate);
 
@@ -144,6 +151,23 @@ class CacheStrategy {
               .firstValue("Date")
               .flatMap(HttpDates::tryParseHttpDate)
               .orElseGet(() -> toUtcDateTime(timeResponseReceived));
+
+      // As per rfc7234 Section 5.3:
+      // ---
+      //   A cache recipient MUST interpret invalid date formats, especially the
+      //   value "0", as representing a time in the past (i.e., "already
+      //   expired").
+      // ---
+      //
+      // So if Expires is invalid, we fall back to the furthest time in the past LocalDateTime can
+      // represent. This has the advantage over approaches like falling back to an arbitrary amount
+      // of time before the response's date, say a minute, in that it won't accidentally pass even
+      // if the user passes in a 'max-stale=60', still satisfying the server's assumed intentions.
+      expires =
+          cacheResponse
+              .headers()
+              .firstValue("Expires")
+              .map(expiresValues -> tryParseHttpDate(expiresValues).orElse(LocalDateTime.MIN));
     }
 
     /** Computes response's age relative to {@code now} as specified by rfc7324 Section 4.2.3. */
@@ -188,7 +212,7 @@ class CacheStrategy {
       return maxAge.isEmpty() && expires.isEmpty();
     }
 
-    CacheStrategy build(Instant now) {
+    CacheStrategy create(Instant now) {
       return new CacheStrategy(this, now);
     }
   }

--- a/methanol/src/test/java/com/github/mizosoft/methanol/AbstractHttpCacheTest.java
+++ b/methanol/src/test/java/com/github/mizosoft/methanol/AbstractHttpCacheTest.java
@@ -24,7 +24,7 @@ package com.github.mizosoft.methanol;
 
 import static com.github.mizosoft.methanol.MutableRequest.GET;
 import static com.github.mizosoft.methanol.internal.Validate.requireState;
-import static com.github.mizosoft.methanol.internal.cache.HttpDates.toHttpDateString;
+import static com.github.mizosoft.methanol.internal.cache.HttpDates.formatHttpDate;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -188,7 +188,7 @@ abstract class AbstractHttpCacheTest {
   }
 
   static String instantToHttpDateString(Instant instant) {
-    return toHttpDateString(toUtcDateTime(instant));
+    return formatHttpDate(toUtcDateTime(instant));
   }
 
   static class ForwardingStore implements Store {

--- a/methanol/src/test/java/com/github/mizosoft/methanol/HttpCacheTest.java
+++ b/methanol/src/test/java/com/github/mizosoft/methanol/HttpCacheTest.java
@@ -23,7 +23,7 @@
 package com.github.mizosoft.methanol;
 
 import static com.github.mizosoft.methanol.MutableRequest.GET;
-import static com.github.mizosoft.methanol.internal.cache.HttpDates.toHttpDateString;
+import static com.github.mizosoft.methanol.internal.cache.HttpDates.formatHttpDate;
 import static com.github.mizosoft.methanol.testing.TestUtils.deflate;
 import static com.github.mizosoft.methanol.testing.TestUtils.gzip;
 import static com.github.mizosoft.methanol.testing.verifiers.Verifiers.verifyThat;
@@ -233,7 +233,7 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     var timeResponseReceived = toUtcDateTime(clock.instant());
     server.enqueue(
         new MockResponse()
-            .setHeader("Expires", toHttpDateString(timeResponseReceived.plusDays(1)))
+            .setHeader("Expires", formatHttpDate(timeResponseReceived.plusDays(1)))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isCacheMiss().hasBody("Pikachu");
 
@@ -246,14 +246,14 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     clock.advance(Duration.ofMillis(1));
     server.enqueue(
         new MockResponse()
-            .setHeader("Expires", toHttpDateString(timeResponseReceived.plusDays(1)))
+            .setHeader("Expires", formatHttpDate(timeResponseReceived.plusDays(1)))
             .setBody("Eevee"));
     verifyThat(send(serverUri)).isConditionalMiss().hasBody("Eevee");
 
     clock.advance(Duration.ofDays(1).plusMillis(1));
     server.enqueue(
         new MockResponse()
-            .setHeader("Expires", toHttpDateString(timeResponseReceived.plusDays(1)))
+            .setHeader("Expires", formatHttpDate(timeResponseReceived.plusDays(1)))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isConditionalMiss().hasBody("Pikachu");
   }
@@ -266,8 +266,8 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     clock.advance(Duration.ofHours(12));
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(timeResponseGenerated))
-            .setHeader("Expires", toHttpDateString(timeResponseGenerated.plusDays(1)))
+            .setHeader("Date", formatHttpDate(timeResponseGenerated))
+            .setHeader("Expires", formatHttpDate(timeResponseGenerated.plusDays(1)))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isCacheMiss().hasBody("Pikachu");
 
@@ -280,16 +280,16 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     clock.advance(Duration.ofMillis(1));
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(timeResponseGenerated))
-            .setHeader("Expires", toHttpDateString(timeResponseGenerated.plusDays(1)))
+            .setHeader("Date", formatHttpDate(timeResponseGenerated))
+            .setHeader("Expires", formatHttpDate(timeResponseGenerated.plusDays(1)))
             .setBody("Eevee"));
     verifyThat(send(serverUri)).isConditionalMiss().hasBody("Eevee");
 
     clock.advance(Duration.ofDays(1).plusMillis(1));
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(timeResponseGenerated))
-            .setHeader("Expires", toHttpDateString(timeResponseGenerated.plusDays(1)))
+            .setHeader("Date", formatHttpDate(timeResponseGenerated))
+            .setHeader("Expires", formatHttpDate(timeResponseGenerated.plusDays(1)))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isConditionalMiss().hasBody("Pikachu");
   }
@@ -704,16 +704,16 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     var date = toUtcDateTime(clock.instant());
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(date))
-            .setHeader("Expires", toHttpDateString(date.minusSeconds(10)))
+            .setHeader("Date", formatHttpDate(date))
+            .setHeader("Expires", formatHttpDate(date.minusSeconds(10)))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isCacheMiss().hasBody("Pikachu");
 
     // Negative freshness lifetime caused by past Expires triggers revalidation
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(date))
-            .setHeader("Expires", toHttpDateString(date.minusSeconds(10)))
+            .setHeader("Date", formatHttpDate(date))
+            .setHeader("Expires", formatHttpDate(date.minusSeconds(10)))
             .setBody("Psyduck"));
     verifyThat(send(serverUri)).isConditionalMiss().hasBody("Psyduck");
   }
@@ -728,22 +728,22 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     // Don't include explicit freshness to trigger heuristics, which relies on Last-Modified
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(date))
-            .setHeader("Last-Modified", toHttpDateString(lastModified))
+            .setHeader("Date", formatHttpDate(date))
+            .setHeader("Last-Modified", formatHttpDate(lastModified))
             .setBody("Pikachu"));
     verifyThat(send(serverUri)).isCacheMiss().hasBody("Pikachu");
 
     // Negative heuristic lifetime caused by future Last-Modified triggers revalidation
     server.enqueue(
         new MockResponse()
-            .setHeader("Date", toHttpDateString(date))
-            .setHeader("Last-Modified", toHttpDateString(lastModified))
+            .setHeader("Date", formatHttpDate(date))
+            .setHeader("Last-Modified", formatHttpDate(lastModified))
             .setBody("Psyduck"));
     verifyThat(send(serverUri))
         .isConditionalMiss()
         .hasBody("Psyduck")
         .networkResponse()
-        .containsRequestHeader("If-Modified-Since", toHttpDateString(lastModified));
+        .containsRequestHeader("If-Modified-Since", formatHttpDate(lastModified));
   }
 
   @StoreParameterizedTest
@@ -2433,35 +2433,35 @@ class HttpCacheTest extends AbstractHttpCacheTest {
         new MockResponse()
             .setBody("abc")
             .setHeader("Cache-Control", "max-age=1")
-            .setHeader("Date", toHttpDateString(date))
-            .setHeader("Last-Modified", toHttpDateString(lastModified)));
+            .setHeader("Date", formatHttpDate(date))
+            .setHeader("Last-Modified", formatHttpDate(lastModified)));
 
     verifyThat(
             send(
                 GET(serverUri)
-                    .header("If-Modified-Since", toHttpDateString(lastModified.plusSeconds(2)))))
+                    .header("If-Modified-Since", formatHttpDate(lastModified.plusSeconds(2)))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
     verifyThat(
             send(
                 GET(serverUri)
-                    .header("If-Modified-Since", toHttpDateString(lastModified.plusSeconds(1)))))
+                    .header("If-Modified-Since", formatHttpDate(lastModified.plusSeconds(1)))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
-    verifyThat(send(GET(serverUri).header("If-Modified-Since", toHttpDateString(lastModified))))
+    verifyThat(send(GET(serverUri).header("If-Modified-Since", formatHttpDate(lastModified))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
 
     verifyThat(
             send(
                 GET(serverUri)
-                    .header("If-Modified-Since", toHttpDateString(lastModified.minusSeconds(1)))))
+                    .header("If-Modified-Since", formatHttpDate(lastModified.minusSeconds(1)))))
         .isCacheHit()
         .hasBody("abc");
     verifyThat(
             send(
                 GET(serverUri)
-                    .header("If-Modified-Since", toHttpDateString(lastModified.minusSeconds(2)))))
+                    .header("If-Modified-Since", formatHttpDate(lastModified.minusSeconds(2)))))
         .isCacheHit()
         .hasBody("abc");
 
@@ -2469,7 +2469,7 @@ class HttpCacheTest extends AbstractHttpCacheTest {
 
     // Preconditions are ignored when the response is stale.
     server.enqueue(new MockResponse().setResponseCode(HTTP_NOT_MODIFIED));
-    verifyThat(send(GET(serverUri).header("If-Modified-Since", toHttpDateString(lastModified))))
+    verifyThat(send(GET(serverUri).header("If-Modified-Since", formatHttpDate(lastModified))))
         .hasCode(HTTP_OK)
         .isConditionalHit()
         .hasBody("abc");
@@ -2484,28 +2484,26 @@ class HttpCacheTest extends AbstractHttpCacheTest {
         new MockResponse()
             .setBody("abc")
             .setHeader("Cache-Control", "max-age=1")
-            .setHeader("Date", toHttpDateString(date)));
+            .setHeader("Date", formatHttpDate(date)));
 
     verifyThat(
-            send(GET(serverUri).header("If-Modified-Since", toHttpDateString(date.plusSeconds(2)))))
+            send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date.plusSeconds(2)))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
     verifyThat(
-            send(GET(serverUri).header("If-Modified-Since", toHttpDateString(date.plusSeconds(1)))))
+            send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date.plusSeconds(1)))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
-    verifyThat(send(GET(serverUri).header("If-Modified-Since", toHttpDateString(date))))
+    verifyThat(send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date))))
         .isExternallyConditionalCacheHit()
         .hasBody("");
 
     verifyThat(
-            send(
-                GET(serverUri).header("If-Modified-Since", toHttpDateString(date.minusSeconds(1)))))
+            send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date.minusSeconds(1)))))
         .isCacheHit()
         .hasBody("abc");
     verifyThat(
-            send(
-                GET(serverUri).header("If-Modified-Since", toHttpDateString(date.minusSeconds(2)))))
+            send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date.minusSeconds(2)))))
         .isCacheHit()
         .hasBody("abc");
 
@@ -2513,7 +2511,7 @@ class HttpCacheTest extends AbstractHttpCacheTest {
 
     // Preconditions are ignored when the response is stale.
     server.enqueue(new MockResponse().setResponseCode(HTTP_NOT_MODIFIED));
-    verifyThat(send(GET(serverUri).header("If-Modified-Since", toHttpDateString(date))))
+    verifyThat(send(GET(serverUri).header("If-Modified-Since", formatHttpDate(date))))
         .hasCode(HTTP_OK)
         .isConditionalHit()
         .hasBody("abc");
@@ -2591,8 +2589,8 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     putInCache(
         new MockResponse()
             .setHeader("ETag", "\"1\"")
-            .setHeader("date", toHttpDateString(date))
-            .setHeader("Last-Modified", toHttpDateString(lastModified))
+            .setHeader("date", formatHttpDate(date))
+            .setHeader("Last-Modified", formatHttpDate(lastModified))
             .setBody("abc"));
 
     // If-None-Match takes precedence over If-Modified-Since.
@@ -2600,7 +2598,7 @@ class HttpCacheTest extends AbstractHttpCacheTest {
             send(
                 GET(serverUri)
                     .header("If-None-Match", "\"1\"") // Satisfied.
-                    .header("If-Modified-Since", toHttpDateString(lastModified)))) // Unsatisfied.
+                    .header("If-Modified-Since", formatHttpDate(lastModified)))) // Unsatisfied.
         .isExternallyConditionalCacheHit()
         .hasBody("");
     verifyThat(
@@ -2609,7 +2607,7 @@ class HttpCacheTest extends AbstractHttpCacheTest {
                     .header("If-None-Match", "\"2\"") // Satisfied.
                     .header(
                         "If-Modified-Since",
-                        toHttpDateString(lastModified.minusSeconds(1))))) // Unsatisfied.
+                        formatHttpDate(lastModified.minusSeconds(1))))) // Unsatisfied.
         .isCacheHit()
         .hasBody("abc");
   }
@@ -2623,10 +2621,10 @@ class HttpCacheTest extends AbstractHttpCacheTest {
     putInCache(
         new MockResponse()
             .setResponseCode(HTTP_MOVED_PERM)
-            .setHeader("Last-Modified", toHttpDateString(lastModified)));
+            .setHeader("Last-Modified", formatHttpDate(lastModified)));
 
     // If-Modified-Since isn't evaluated.
-    verifyThat(send(GET(serverUri).header("If-Modified-Since", toHttpDateString(lastModified))))
+    verifyThat(send(GET(serverUri).header("If-Modified-Since", formatHttpDate(lastModified))))
         .isCacheHit();
   }
 

--- a/methanol/src/test/java/com/github/mizosoft/methanol/MultiLevelHttpCacheTest.java
+++ b/methanol/src/test/java/com/github/mizosoft/methanol/MultiLevelHttpCacheTest.java
@@ -22,7 +22,7 @@
 
 package com.github.mizosoft.methanol;
 
-import static com.github.mizosoft.methanol.internal.cache.HttpDates.toHttpDateString;
+import static com.github.mizosoft.methanol.internal.cache.HttpDates.formatHttpDate;
 import static com.github.mizosoft.methanol.testing.verifiers.Verifiers.verifyThat;
 import static java.net.HttpURLConnection.HTTP_NOT_MODIFIED;
 
@@ -206,7 +206,7 @@ class MultiLevelHttpCacheTest extends AbstractHttpCacheTest {
     server.enqueue(
         new MockResponse()
             .setHeader("Cache-Control", "max-age=1")
-            .setHeader("Last-Modified", toHttpDateString(lastModified))
+            .setHeader("Last-Modified", formatHttpDate(lastModified))
             .setHeader("X-Version", "1")
             .setBody("Pikachu"));
     verifyThat(send(client)).isCacheMiss().hasBody("Pikachu");
@@ -228,7 +228,7 @@ class MultiLevelHttpCacheTest extends AbstractHttpCacheTest {
         .hasBody("Pikachu")
         .networkResponse()
         .isExternallyConditionalCacheHit()
-        .containsRequestHeader("If-Modified-Since", toHttpDateString(lastModified))
+        .containsRequestHeader("If-Modified-Since", formatHttpDate(lastModified))
         .hasNoBody();
     verifyThat(send(client)).isCacheHit().containsHeader("X-Version", "2").hasBody("Pikachu");
   }


### PR DESCRIPTION
This wasn't guaranteed previously as an invalid `Expires` would've caused the cache to fall back to heuristic freshness, which might've made the response fresh & hence serveable. 

Closes #64