### PR TITLE
SPI touch-ups

### DIFF
--- a/methanol/src/main/java/com/github/mizosoft/methanol/AdapterCodec.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/AdapterCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Moataz Abdelnasser
+ * Copyright (c) 2024 Moataz Abdelnasser
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.github.mizosoft.methanol.BodyAdapter.Decoder;
 import com.github.mizosoft.methanol.BodyAdapter.Encoder;
-import com.github.mizosoft.methanol.internal.spi.ServiceCache;
+import com.github.mizosoft.methanol.internal.spi.BodyAdapterProviders;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpResponse.BodyHandler;
@@ -44,11 +44,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
  * and a {@link MediaType} specifying the desired format.
  */
 public final class AdapterCodec {
-  private static final ServiceCache<Encoder> encodersServiceCache =
-      new ServiceCache<>(Encoder.class);
-  private static final ServiceCache<Decoder> decodersServiceCache =
-      new ServiceCache<>(Decoder.class);
-
   /**
    * Codec for the installed encoders & decoders. This is lazily created in a racy manner, which is
    * OK since ServiceCache makes sure we see a constant snapshot of the services.
@@ -181,8 +176,7 @@ public final class AdapterCodec {
     var installedCodec = lazyInstalledCodec;
     if (installedCodec == null) {
       installedCodec =
-          new AdapterCodec(
-              encodersServiceCache.getProviders(), decodersServiceCache.getProviders());
+          new AdapterCodec(BodyAdapterProviders.encoders(), BodyAdapterProviders.decoders());
       lazyInstalledCodec = installedCodec;
     }
     return installedCodec;

--- a/methanol/src/main/java/com/github/mizosoft/methanol/BodyAdapter.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/BodyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Moataz Abdelnasser
+ * Copyright (c) 2024 Moataz Abdelnasser
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
 
 package com.github.mizosoft.methanol;
 
-import com.github.mizosoft.methanol.internal.spi.BodyAdapterFinder;
+import com.github.mizosoft.methanol.internal.spi.BodyAdapterProviders;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.util.List;
@@ -74,7 +74,7 @@ public interface BodyAdapter {
 
     /** Returns an immutable list containing the installed encoders. */
     static List<Encoder> installed() {
-      return BodyAdapterFinder.findInstalledEncoders();
+      return BodyAdapterProviders.encoders();
     }
 
     /**
@@ -119,7 +119,7 @@ public interface BodyAdapter {
 
     /** Returns an immutable list containing the installed decoders. */
     static List<Decoder> installed() {
-      return BodyAdapterFinder.findInstalledDecoders();
+      return BodyAdapterProviders.decoders();
     }
 
     /**

--- a/methanol/src/main/java/com/github/mizosoft/methanol/BodyDecoder.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/BodyDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Moataz Abdelnasser
+ * Copyright (c) 2024 Moataz Abdelnasser
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@ package com.github.mizosoft.methanol;
 
 import static java.util.Objects.requireNonNull;
 
-import com.github.mizosoft.methanol.internal.spi.DecoderFactoryFinder;
+import com.github.mizosoft.methanol.internal.spi.BodyDecoderFactoryProviders;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.util.List;
 import java.util.Map;
@@ -114,7 +114,7 @@ public interface BodyDecoder<T> extends BodySubscriber<T> {
      *     factories
      */
     static List<Factory> installedFactories() {
-      return DecoderFactoryFinder.findInstalledFactories();
+      return BodyDecoderFactoryProviders.factories();
     }
 
     /**
@@ -124,7 +124,7 @@ public interface BodyDecoder<T> extends BodySubscriber<T> {
      * overridable.
      */
     static Map<String, Factory> installedBindings() {
-      return DecoderFactoryFinder.getInstalledBindings();
+      return BodyDecoderFactoryProviders.bindings();
     }
 
     /**

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/BodyAdapterProviders.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/BodyAdapterProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Moataz Abdelnasser
+ * Copyright (c) 2024 Moataz Abdelnasser
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,18 +27,17 @@ import com.github.mizosoft.methanol.BodyAdapter.Encoder;
 import java.util.List;
 
 /** Utility class for loading/caching {@code Encoder/Decoder} providers. */
-public class BodyAdapterFinder {
+public class BodyAdapterProviders {
+  private static final ServiceProviders<Encoder> encoders = new ServiceProviders<>(Encoder.class);
+  private static final ServiceProviders<Decoder> decoders = new ServiceProviders<>(Decoder.class);
 
-  private static final ServiceCache<Encoder> encodersServiceCache = new ServiceCache<>(Encoder.class);
-  private static final ServiceCache<Decoder> decodersServiceCache = new ServiceCache<>(Decoder.class);
+  private BodyAdapterProviders() {}
 
-  private BodyAdapterFinder() {} // non-instantiable
-
-  public static List<Encoder> findInstalledEncoders() {
-    return encodersServiceCache.getProviders();
+  public static List<Encoder> encoders() {
+    return encoders.get();
   }
 
-  public static List<Decoder> findInstalledDecoders() {
-    return decodersServiceCache.getProviders();
+  public static List<Decoder> decoders() {
+    return decoders.get();
   }
 }

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/ServiceProviders.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/ServiceProviders.java
@@ -32,23 +32,23 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** An object that loads {@literal &} caches service providers. */
-public final class ServiceCache<S> {
-  private static final Logger logger = System.getLogger(ServiceCache.class.getName());
+public final class ServiceProviders<S> {
+  private static final Logger logger = System.getLogger(ServiceProviders.class.getName());
 
   private final Lazy<List<S>> providers;
 
-  public ServiceCache(Class<S> service) {
+  public ServiceProviders(Class<S> service) {
     requireNonNull(service);
     this.providers = Lazy.of(() -> loadProviders(service));
   }
 
-  public List<S> getProviders() {
+  public List<S> get() {
     return providers.get();
   }
 
   private static <U> List<U> loadProviders(Class<U> service) {
     return ServiceLoader.load(service, service.getClassLoader()).stream()
-        .map(ServiceCache::tryGet)
+        .map(ServiceProviders::tryGet)
         .filter(Objects::nonNull)
         .collect(Collectors.toUnmodifiableList());
   }
@@ -59,7 +59,7 @@ public final class ServiceCache<S> {
     } catch (ServiceConfigurationError error) {
       logger.log(
           Level.WARNING,
-          "provider <" + provider.type() + "> will be ignored as it couldn't be instantiated",
+          "Provider <" + provider.type() + "> will be ignored as it couldn't be instantiated",
           error);
       return null;
     }


### PR DESCRIPTION
 - Get encoders/decoders across AdapterCodec & Encoder/Decoder.installed() from one place.
 - Correct behavior for overriding default providers.
 - Refactorings.