### PR TITLE
Call Queue::add instead of Queue::offer

### DIFF
--- a/methanol/src/main/java/com/github/mizosoft/methanol/MultipartBodyPublisher.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/MultipartBodyPublisher.java
@@ -584,7 +584,7 @@ public final class MultipartBodyPublisher implements MimeBodyPublisher {
 
     @Override
     public void onNext(ByteBuffer item) {
-      buffers.offer(item);
+      buffers.add(item);
       downstream.fireOrKeepAliveOnNext();
     }
 
@@ -598,7 +598,7 @@ public final class MultipartBodyPublisher implements MimeBodyPublisher {
     @Override
     public void onComplete() {
       abort(false);
-      buffers.offer(END_OF_PART);
+      buffers.add(END_OF_PART);
       downstream.fireOrKeepAlive();
     }
 

--- a/methanol/src/main/java/com/github/mizosoft/methanol/WritableBodyPublisher.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/WritableBodyPublisher.java
@@ -285,7 +285,7 @@ public final class WritableBodyPublisher implements BodyPublisher, Flushable, Au
     var buffer = sinkBuffer;
     if (buffer != null && buffer.position() > 0) {
       sinkBuffer = null;
-      pipe.offer(buffer.flip().asReadOnlyBuffer());
+      pipe.add(buffer.flip().asReadOnlyBuffer());
       return true;
     }
     return false;
@@ -298,7 +298,7 @@ public final class WritableBodyPublisher implements BodyPublisher, Flushable, Au
         if (!submittedSentinel) {
           submittedSentinel = true;
           flushBuffer();
-          pipe.offer(CLOSED_SENTINEL);
+          pipe.add(CLOSED_SENTINEL);
         }
       } finally {
         writeLock.unlock();
@@ -340,7 +340,7 @@ public final class WritableBodyPublisher implements BodyPublisher, Flushable, Au
           }
           written += Utils.copyRemaining(src, buffer);
           if (!buffer.hasRemaining()) {
-            pipe.offer(buffer.flip().asReadOnlyBuffer());
+            pipe.add(buffer.flip().asReadOnlyBuffer());
             signalsAvailable = true;
             buffer = null;
           }

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/flow/AbstractQueueSubscription.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/flow/AbstractQueueSubscription.java
@@ -62,17 +62,17 @@ public class AbstractQueueSubscription<T> extends AbstractPollableSubscription<T
   }
 
   protected void submit(T item) {
-    queue.offer(item);
+    queue.add(item);
     fireOrKeepAliveOnNext();
   }
 
   protected void submitSilently(T item) {
-    queue.offer(item);
+    queue.add(item);
   }
 
   protected void submitAndComplete(T lastItem) {
-    queue.offer(lastItem);
-    queue.offer(sentinel);
+    queue.add(lastItem);
+    queue.add(sentinel);
     fireOrKeepAlive();
   }
 
@@ -94,7 +94,7 @@ public class AbstractQueueSubscription<T> extends AbstractPollableSubscription<T
   }
 
   protected void complete() {
-    queue.offer(sentinel);
+    queue.add(sentinel);
     fireOrKeepAlive();
   }
 }


### PR DESCRIPTION
Make sure we're calling `Queue::add` instead of `Queue::offer` when we have no bound considerations in mind.