### PR TITLE
Skip running tests of methanol-brotli on aarch64

### DIFF
--- a/methanol-brotli/src/test/java/com/github/mizosoft/methanol/brotli/internal/BrotliDecoderTest.java
+++ b/methanol-brotli/src/test/java/com/github/mizosoft/methanol/brotli/internal/BrotliDecoderTest.java
@@ -38,7 +38,9 @@ import java.util.Base64;
 import org.brotli.dec.BrotliInputStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
+@DisabledOnOs(architectures = "aarch64")
 class BrotliDecoderTest {
   private static final String GOOD =
       "ocAXACEazuXPqLgaOX42Jj+EdAT91430gPT27km/6WbK3kTpTWJBJkmAeWoBWebW3oK/qHGuI8e6WIjsH5Qqmrt4ByakvCwb73IT2E7OA3MDpxszTNgAn1xJrzB3qoFjKUOWYBi+VYYbqmhiWlHmHtjbjdVfy3jnR9rs6X7PuzmVyW93/LLKaujeyU6O/8yJu4RSPpCDX8afTBrKXY6Vh/5ZqGfsC9oJGm3XX+klIwK/5sMFqil13dFUJH/xZhMm/JyLMb+HN6gerSzhhBGBAbNBkYaDVHKTZyy28+4XjDnIaY83AkYLSCJ7BIUq0b90zmwYPG4A";

--- a/methanol-brotli/src/test/java/com/github/mizosoft/methanol/brotli/internal/BrotliLoaderTest.java
+++ b/methanol-brotli/src/test/java/com/github/mizosoft/methanol/brotli/internal/BrotliLoaderTest.java
@@ -36,8 +36,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
 
+@DisabledOnOs(architectures = "aarch64")
 class BrotliLoaderTest {
 
   @Test


### PR DESCRIPTION
Currently the brotli library only supports X86/X64 and fails with "java.lang.UnsupportedOperationException: unrecognized architecture: aarch64" on aarch64 architectures.