### PR TITLE
Make service provider lookup OSGi aware

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ kotlinx-serialization = "[1.9.0,2)"
 assertk = "0.28.1"
 kotlin = "2.2.20"
 moshi = "[1.15.2,2)"
-bnd = "7.1.0"
+bnd = "7.2.1"
 eclipse-osgi = "3.20.0"
 versions-plugin = "0.52.0"
 nexus-publish = "2.0.0"
@@ -53,6 +53,7 @@ graalvm-plugin = "0.10.1"
 kotlin-serialization-plugin = "2.1.0"
 dokka-plugin = "1.9.20"
 coveralls-jacoco-plugin = "1.2.20"
+aries-spifly = "1.3.7"
 
 [libraries]
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
@@ -117,8 +118,10 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 bnd-lib = { module = "biz.aQute.bnd:biz.aQute.bndlib", version.ref = "bnd" }
 bnd-resolve = { module = "biz.aQute.bnd:biz.aQute.resolve", version.ref = "bnd" }
 bnd-repository = { module = "biz.aQute.bnd:biz.aQute.repository", version.ref = "bnd" }
+bnd-annotations = { module = "biz.aQute.bnd:biz.aQute.bnd.annotation", version.ref = "bnd" }
 eclipse-osgi = { module = "org.eclipse.platform:org.eclipse.osgi", version.ref = "eclipse-osgi" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+aries-spifly = { module = "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle", version.ref = "aries-spifly"}
 
 [plugins]
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions-plugin" }

--- a/methanol-brotli/build.gradle.kts
+++ b/methanol-brotli/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
   implementation(project(":methanol"))
+  api(libs.bnd.annotations)
   testImplementation(project(":methanol-testing"))
   testImplementation(libs.brotli.dec)
 }

--- a/methanol-brotli/src/main/java/com/github/mizosoft/methanol/brotli/internal/BrotliBodyDecoderFactory.java
+++ b/methanol-brotli/src/main/java/com/github/mizosoft/methanol/brotli/internal/BrotliBodyDecoderFactory.java
@@ -24,11 +24,13 @@ package com.github.mizosoft.methanol.brotli.internal;
 
 import com.github.mizosoft.methanol.BodyDecoder;
 import com.github.mizosoft.methanol.decoder.AsyncBodyDecoder;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import java.io.IOException;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.util.concurrent.Executor;
 
 /** {@code BodyDecoder.Factory} provider for brotli encoding. */
+@ServiceProvider(BodyDecoder.Factory.class)
 public final class BrotliBodyDecoderFactory implements BodyDecoder.Factory {
   static final String BROTLI_ENCODING = "br";
 

--- a/methanol-brotli/src/main/java/module-info.java
+++ b/methanol-brotli/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module methanol.brotli {
   requires methanol;
   requires static org.checkerframework.checker.qual;
   requires static com.google.errorprone.annotations;
+  requires static biz.aQute.bnd.annotation;
 
   provides com.github.mizosoft.methanol.BodyDecoder.Factory with
       com.github.mizosoft.methanol.brotli.internal.BrotliBodyDecoderFactory;

--- a/methanol-brotli/src/main/resources/META-INF/services/com.github.mizosoft.methanol.BodyDecoder$Factory
+++ b/methanol-brotli/src/main/resources/META-INF/services/com.github.mizosoft.methanol.BodyDecoder$Factory
@@ -1,1 +1,0 @@
-com.github.mizosoft.methanol.brotli.internal.BrotliBodyDecoderFactory

--- a/methanol/build.gradle.kts
+++ b/methanol/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 dependencies {
+  api(libs.bnd.annotations)
   testImplementation(libs.mockwebserver)
   testImplementation(libs.reactivestreams)
   testImplementation(libs.jimfs)

--- a/methanol/src/main/java/com/github/mizosoft/methanol/AdapterCodec.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/AdapterCodec.java
@@ -31,6 +31,9 @@ import com.github.mizosoft.methanol.BodyAdapter.Hints;
 import com.github.mizosoft.methanol.internal.Utils;
 import com.github.mizosoft.methanol.internal.spi.ServiceProviders;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
+import aQute.bnd.annotation.spi.ServiceConsumers;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
@@ -47,6 +50,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
  * implementations. The correct adapter is selected based on the object type and caller's {@link
  * Hints}, typically containing the {@link MediaType} of the desired mapping format.
  */
+@ServiceConsumers({
+  @ServiceConsumer(value=Encoder.class, resolution=Resolution.OPTIONAL),
+  @ServiceConsumer(value=Decoder.class, resolution=Resolution.OPTIONAL)
+})
 public final class AdapterCodec {
   private static final ServiceProviders<Encoder> installedEncoders =
       new ServiceProviders<>(Encoder.class);

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/decoder/DeflateBodyDecoderFactory.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/decoder/DeflateBodyDecoderFactory.java
@@ -22,11 +22,14 @@
 
 package com.github.mizosoft.methanol.internal.decoder;
 
+import com.github.mizosoft.methanol.BodyDecoder;
 import com.github.mizosoft.methanol.decoder.AsyncDecoder;
 import com.github.mizosoft.methanol.internal.annotations.DefaultProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
 /** {@code BodyDecoder.Factory} for "deflate". */
 @DefaultProvider
+@ServiceProvider(BodyDecoder.Factory.class)
 public final class DeflateBodyDecoderFactory extends AsyncBodyDecoderFactory {
 
   /**

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/decoder/GzipBodyDecoderFactory.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/decoder/GzipBodyDecoderFactory.java
@@ -22,11 +22,14 @@
 
 package com.github.mizosoft.methanol.internal.decoder;
 
+import com.github.mizosoft.methanol.BodyDecoder;
 import com.github.mizosoft.methanol.decoder.AsyncDecoder;
 import com.github.mizosoft.methanol.internal.annotations.DefaultProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
 /** {@code BodyDecoder.Factory} for "gzip". */
 @DefaultProvider
+@ServiceProvider(BodyDecoder.Factory.class)
 public final class GzipBodyDecoderFactory extends AsyncBodyDecoderFactory {
 
   /** Creates a new {@code GzipBodyDecoderFactory}. Meant to be called by {@code ServiceLoader}. */

--- a/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/BodyDecoderFactoryProviders.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/internal/spi/BodyDecoderFactoryProviders.java
@@ -24,6 +24,8 @@ package com.github.mizosoft.methanol.internal.spi;
 
 import com.github.mizosoft.methanol.BodyDecoder;
 import com.github.mizosoft.methanol.internal.annotations.DefaultProvider;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +34,7 @@ import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** Utility class for finding decoder factories. */
+@ServiceConsumer(value =BodyDecoder.Factory.class, resolution = Resolution.OPTIONAL)
 public class BodyDecoderFactoryProviders {
   private static final ServiceProviders<BodyDecoder.Factory> factories =
       new ServiceProviders<>(BodyDecoder.Factory.class);

--- a/methanol/src/main/java/module-info.java
+++ b/methanol/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module methanol {
   requires transitive java.net.http;
   requires static org.checkerframework.checker.qual;
   requires static com.google.errorprone.annotations;
+  requires static biz.aQute.bnd.annotation;
   requires jdk.httpserver;
 
   exports com.github.mizosoft.methanol;

--- a/methanol/src/main/resources/META-INF/services/com.github.mizosoft.methanol.BodyDecoder$Factory
+++ b/methanol/src/main/resources/META-INF/services/com.github.mizosoft.methanol.BodyDecoder$Factory
@@ -1,2 +1,0 @@
-com.github.mizosoft.methanol.internal.decoder.GzipBodyDecoderFactory
-com.github.mizosoft.methanol.internal.decoder.DeflateBodyDecoderFactory

--- a/osgi-test/build.gradle.kts
+++ b/osgi-test/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   testImplementation(libs.bnd.repository)
   testImplementation(libs.eclipse.osgi)
   testImplementation(libs.kotlin.stdlib)
+  testImplementation(libs.aries.spifly)
 }
 
 tasks.test {


### PR DESCRIPTION
Generate Service Loader Mediator Spec metadata and service descriptor files (in META-INF/services) with the help of Bnd annotations.

This closes #176