### PR TITLE
Call RetryInterceptor.Listener.onExhaustion(...) even when throwOnExh…

### DIFF
--- a/methanol-kotlin/src/test/kotlin/com/github/mizosoft/methanol/kotlin/RetryTest.kt
+++ b/methanol-kotlin/src/test/kotlin/com/github/mizosoft/methanol/kotlin/RetryTest.kt
@@ -510,7 +510,7 @@ class RetryTest(private val server: MockWebServer) {
   }
 
   @Test
-  fun retryListenerCompletion() {
+  fun retryListenerCompletionByExhaustion() {
     val events = mutableListOf<RetryEvent>()
     val client = Client {
       adapterCodec {
@@ -548,7 +548,7 @@ class RetryTest(private val server: MockWebServer) {
       assertThat(retry.delay).isEqualTo(Duration.ZERO)
     }
     events.removeFirst()
-    assertThat(events).first().isInstanceOf(Complete::class).given { complete ->
+    assertThat(events).first().isInstanceOf(Exhaustion::class).given { complete ->
       verifyThat(complete.context.request()).hasUri(serverUri)
     }
   }

--- a/methanol/src/main/java/com/github/mizosoft/methanol/RetryInterceptor.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/RetryInterceptor.java
@@ -228,11 +228,10 @@ public final class RetryInterceptor implements Methanol.Interceptor {
     if (context.deadline().isPresent() && !clock.instant().isBefore(context.deadline().get())) {
       return Timeout.INSTANCE; // Listener will be called by timeout().
     } else if (context.retryCount() >= maxRetries) {
+      listener.onExhaustion(context);
       if (throwOnExhaustion) {
-        listener.onExhaustion(context);
         return Exhausted.INSTANCE;
       } else {
-        listener.onComplete(context);
         return Complete.INSTANCE;
       }
     } else {
@@ -614,6 +613,7 @@ public final class RetryInterceptor implements Methanol.Interceptor {
     /**
      * Called when the interceptor exhausts allowed retry attempts. The given context's {@link
      * Context#retryCount()} equals the specified {@link Builder#maxRetries(int)}.
+     * This is called even when the interceptor was not responsible for previous retries.
      */
     default void onExhaustion(Context<?> context) {}
   }

--- a/methanol/src/main/java/com/github/mizosoft/methanol/RetryInterceptor.java
+++ b/methanol/src/main/java/com/github/mizosoft/methanol/RetryInterceptor.java
@@ -611,9 +611,9 @@ public final class RetryInterceptor implements Methanol.Interceptor {
     default void onComplete(Context<?> context) {}
 
     /**
-     * Called when the interceptor exhausts allowed retry attempts. The given context's {@link
-     * Context#retryCount()} equals the specified {@link Builder#maxRetries(int)}.
-     * This is called even when the interceptor was not responsible for previous retries.
+     * Called when the interceptor exhausts allowed retry attempts without a successful response.
+     * The given context's {@link Context#retryCount()} is equal to the specified {@link
+     * Builder#maxRetries(int)}.
      */
     default void onExhaustion(Context<?> context) {}
   }

--- a/methanol/src/test/java/com/github/mizosoft/methanol/RetryInterceptorClientTest.java
+++ b/methanol/src/test/java/com/github/mizosoft/methanol/RetryInterceptorClientTest.java
@@ -394,7 +394,7 @@ class RetryInterceptorClientTest {
   }
 
   @Test
-  void retryListenerCompletion() throws Exception {
+  void retryListenerCompletionByExhaustion() throws Exception {
     var events = new ArrayList<RetryEvent>();
     var client =
         Methanol.newBuilder()
@@ -431,7 +431,7 @@ class RetryInterceptorClientTest {
             });
     assertThat(events)
         .element(2)
-        .asInstanceOf(type(Complete.class))
+        .asInstanceOf(type(Exhaustion.class))
         .satisfies(complete -> verifyThat(complete.context.request()).hasUri(serverUri));
   }
 


### PR DESCRIPTION
…austion is false.

Clarify that RetryInterceptor.Listener.onExhaustion(...) is called even when the interceptor was not responsible for previous retries. This closes #188